### PR TITLE
Fix Bitcoin project link on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
       <img src="https://tse3.mm.bing.net/th/id/OIP.jJ-hm3P4DVgPM_JwqimwEgHaEO?pid=Api" alt="Bitcoin Forecasting">
       <h3>Bitcoin Price Forecasting (LSTM)</h3>
       <p>Forecast Bitcoin trends using LSTM and time-series data.</p>
-    <a href="https://github.com/CherylMachingura/cheryltaf85.github.io/tree/main/projects/E-Commerce-Late-Delivery-Prediction">View Project</a>
+      <a href="https://github.com/CherylMachingura/cheryltaf85.github.io/tree/main/projects/Bitcoin%20Price%20Forecasting%20using%20LSTM">View Project</a>
     </div>
     
   </div>


### PR DESCRIPTION
## Summary
- fix Bitcoin project link to point to its correct folder

## Testing
- `npx --yes htmlhint index.html` (fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)


------
https://chatgpt.com/codex/tasks/task_e_68941c72d2f08326b1dedec4cfb519d2