### PR TITLE
Fix Bitcoin project link

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
       <img src="https://tse3.mm.bing.net/th/id/OIP.jJ-hm3P4DVgPM_JwqimwEgHaEO?pid=Api" alt="Bitcoin Forecasting">
       <h3>Bitcoin Price Forecasting (LSTM)</h3>
       <p>Forecast Bitcoin trends using LSTM and time-series data.</p>
-    <a href="https://github.com/CherylMachingura/cheryltaf85.github.io/tree/main/projects/E-Commerce-Late-Delivery-Prediction">View Project</a>
+      <a href="https://github.com/CherylMachingura/cheryltaf85.github.io/tree/main/projects/Bitcoin%20Price%20Forecasting%20using%20LSTM">View Project</a>
     </div>
     
   </div>


### PR DESCRIPTION
## Summary
- fix Bitcoin Price Forecasting project card link so it points to the correct folder
- confirm project cards reference existing directories

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689422ff6e3c832693a6c9fba724838a